### PR TITLE
fix/tests: use `require` for loading components

### DIFF
--- a/tests/station01.test.tsx
+++ b/tests/station01.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import renderer, { act } from 'react-test-renderer'
-import { App } from '../src/App'
 import { fetchMock } from './mock/fetch'
+
+const { App } = require('../src/App') as { App: React.ComponentType<{}> }
 
 describe('Station No.1', () => {
   const fetch = jest.fn()

--- a/tests/station02.test.tsx
+++ b/tests/station02.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import renderer, { act } from 'react-test-renderer'
-import { App } from '../src/App'
 import { fetchMock } from './mock/fetch'
 import { createAsync } from './utils/createAsync'
 
+const { App } = require('../src/App') as { App: React.ComponentType<{}> }
 
 describe('Station No.2', () => {
   const fetch = jest.fn()

--- a/tests/station03.test.tsx
+++ b/tests/station03.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
-import { App } from '../src/App'
 import { fetchMock } from './mock/fetch'
 import { createAsync } from './utils/createAsync'
+
+const { App } = require('../src/App') as { App: React.ComponentType<{}> }
 
 describe('Station No.3', () => {
   const fetch = jest.fn()

--- a/tests/station04.test.tsx
+++ b/tests/station04.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { act } from 'react-test-renderer'
-import { App } from '../src/App'
 import { fetchMock } from './mock/fetch'
 import { createAsync } from './utils/createAsync'
+
+const { App } = require('../src/App') as { App: React.ComponentType<{}> }
 
 describe('Station No.4', () => {
   const fetch = jest.fn()

--- a/tests/station05.test.tsx
+++ b/tests/station05.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import renderer, { act } from 'react-test-renderer'
-import { App } from '../src/App'
 import { fetchMock } from './mock/fetch'
 import { createAsync } from './utils/createAsync'
+
+const { App } = require('../src/App') as { App: React.ComponentType<{}> }
 
 describe('Station No.5', () => {
   const fetch = jest.fn()

--- a/tests/station06.test.tsx
+++ b/tests/station06.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { act } from 'react-test-renderer'
-import { App } from '../src/App'
 import { imageUrl, fetchMock } from './mock/fetch'
 import { createAsync } from './utils/createAsync'
+
+const { App } = require('../src/App') as { App: React.ComponentType<{}> }
 
 describe('<App />', () => {
   const callback = {

--- a/tests/station11.test.tsx
+++ b/tests/station11.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import { act } from 'react-test-renderer'
-import { App } from '../src/App'
-import { DogListContainer } from '../src/DogListContainer'
 import { fetchMock } from './mock/fetch'
 import { createAsync } from './utils/createAsync'
+
+const { App } = require('../src/App') as { App: React.ComponentType<{}> }
+const { DogListContainer } = require('../src/DogListContainer') as {
+  DogListContainer: React.ComponentType<{}>
+}
 
 describe('<DogListContainer />', () => {
   const fetch = jest.fn()


### PR DESCRIPTION
named exportではなくdefault exportを使用したことによるランタイムエラーをCLIが捕捉できないため，応急処置として`require`を用いてロードする．

このままだとコンポーネントファイルが構文エラーの場合同様に失敗するが，その場合ブラウザでもエラーを再現することになるはずなのでひとまずこれで十分かと．CLI/Railway CoreのJestのランタイムエラー捕捉はのちほど対応する．

<img width="878" alt="image" src="https://user-images.githubusercontent.com/298748/159645915-bfc0029c-071e-465b-b106-1ff7e9d955e3.png">
