### PR TITLE
refactor station11-test

### DIFF
--- a/tests/station11.test.tsx
+++ b/tests/station11.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { fetchMock } from './mock/fetch'
 
 const { App } = (await import('../src/App')) as { App: React.ComponentType<{}> }
@@ -51,8 +51,12 @@ describe('<App />', () => {
     expect(button).toBeTruthy()
 
     expect(fetch).toBeCalled()
-    const imgList = res.container.querySelectorAll('img')
-
-    expect(imgList.length).toBeGreaterThan(0)
+    await waitFor(() => {
+      const imgList = res.container.querySelectorAll('img')
+      expect(imgList.length).toBeGreaterThan(1)
+      imgList.forEach((img) => {
+        expect(img.src).not.toBe('');
+      })
+    })
   })
 })


### PR DESCRIPTION
# 概要

React初級Station11のテストで、fetch後に画像のリストが表示されることのテストを改善

# 変更点
- imgタグの個数を確認する部分を「0個より多い」から「１個より多い」ことを判定するように変更
- imgタグのsrc属性に「""」以外の中身が入っていることを確認するように変更

# 変更の意図
https://github.com/TechTrain-Community/RailwayForum/discussions/446
https://github.com/TechTrain-Community/RailwayForum/discussions/546
- この辺りにあるような、意図せずクリアになってしまう問題は、「fetch後にimgタグのリストが表示されること」のテストで、<App />内のimgタグが一つ以上存在するかを確認していたから。
- このままだと、サイトトップの画像のimgタグを拾ってきてしまい、imgタグが存在すると判定してテストが通ってしまっていた？？
  - そこで、imgタグの個数を「１個より多い」ことを判定し、トップの画像以外にimgタグが存在するかを確認するように変更
  - imgのsrcまで確認することで、imgタグは配置されているがurlがうまく渡されておらず画像が表示されていない場合にテストが通ってしまうことを防止
